### PR TITLE
terraform: configure node types and worker node count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+terraform/variables.auto.tfvars

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,8 +3,9 @@
 This directory contains Terraform code, which spawns a Kubernetes cluster in a
 Packet datacenter to perform the benchmark on.
 
-To get it up and running, please create a file `variables.auto.tfvars`
-in the `terraform` sub-directory and define these variables:
+To configure your cluster, please copy the file `variables.auto.tfvars.template` 
+to `variables.auto.tfvars`, then edit `variables.auto.tfvars` and set the
+variables as discussed below.
 
 ```
 dns_zone          = "cluster.example.com"
@@ -19,9 +20,12 @@ Optionally, you may also set:
 cluster_name="my-lokomotive-benchmarkcluster" 
 facility="<packet dataceter>"
 ssh_keys=["list of keys to grant ssh access to nodes"]
+controller_node_type = "t1.small"
+worker_node_type = "t1.small"
+worker_node_count = "2"   #  must be 2 or higher
 ```
 
-The above variables are defined in the `cluster.tf` file.
+F.y.i, The above variables are defined in the `cluster.tf` file.
 
-After completing the initial set-up, please run `terraform init` in the
+After completing the initial configuration, please run `terraform init` in the
 terraform sub-directory.

--- a/terraform/cluster.tf
+++ b/terraform/cluster.tf
@@ -20,7 +20,7 @@ variable "packet_auth_token" {
 variable "cluster_name" {
   type        = "string"
   description = "Name of the cluster."
-  default     = "cluster"
+  default     = "lokomotive-benchmark"
 }
 variable "facility" {
   type        = "string"
@@ -33,6 +33,21 @@ variable "ssh_keys" {
   default     = [
     "~/.ssh/.id_rsa.pub"
   ]
+}
+variable "controller_node_type" {
+  type        = "string"
+  description = "Packet server type to use for controller nodes."
+  default     = "t1.small"
+}
+variable "worker_node_type" {
+  type        = "string"
+  description = "Packet server type to use for worker nodes."
+  default     = "t1.small"
+}
+variable "worker_node_count" {
+  type        = "string"
+  description = "Number of worker nodes in the cluster. Must be 2 or higher."
+  default     = "2"
 }
 
 data "aws_route53_zone" "cluster" {
@@ -73,9 +88,9 @@ module "packet-svc-mesh-benchmark" {
   facility     = "${var.facility}"
 
   controller_count = "1"
+  controller_type = "${var.controller_node_type}"
 
-  # This should be 2 or higher, as one worker node needs to be dedicated for running load generator
-  worker_count              = "2"
+  worker_count              = "${var.worker_node_count}"
   worker_nodes_hostnames    = "${concat("${module.worker-pool-0.worker_nodes_hostname}")}"
   worker_nodes_public_ipv4s = "${concat("${module.worker-pool-0.worker_nodes_public_ipv4}")}"
   management_cidrs = ["${var.management_cidrs}"]
@@ -102,7 +117,8 @@ module "worker-pool-0" {
   facility     = "${var.facility}"
 
   pool_name = "workers"
-  count     = "2"
+  count     = "${var.worker_node_count}"
+  type      = "${var.worker_node_type}"
 
   kubeconfig = "${module.packet-svc-mesh-benchmark.kubeconfig}"
 }

--- a/terraform/variables.auto.tfvars.template
+++ b/terraform/variables.auto.tfvars.template
@@ -1,0 +1,22 @@
+### Mandatory settings
+
+dns_zone          = "cluster.example.com"
+
+# List of CIDRs allowed to ssh into nodes.
+# You can get your IP by executing 'curl -4 icanhazip.com'
+management_cidrs  = ["cird1/mask", "cidr2/mask", "<your ip address>/32"]
+
+packet_auth_token = "<packet API token>"
+packet_project_id = "<packet project id>"
+
+
+### Optional settings
+
+facility="ams1"
+cluster_name="lokomotive-benchmark"
+
+ssh_keys=["~/.ssh/.id_rsa.pub"]
+
+controller_node_type = "t1.small"
+worker_node_type = "t1.small"
+worker_node_count = "2"   #  must be 2 or higher


### PR DESCRIPTION
This change adds variables to configure the node type of
worker nodes and controller, and to set the number of worker
nodes. The documentation in terraform/ was updated accordingly,
and a template file was added to ease set-up.

Lastly, the change contains a .gitignore that prevents
accidental commit of terraform/variables.auto.tfvars since
that file contains settings for specific clusters, and may
contain secrets.