### PR TITLE
scripts: introduce configurable number of load gen threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,17 @@ Before continuing, make sure the `KUBECONFIG` environment variable points to
 the kubernetes configuration of the correct cluster.
 
 You're now set up to start a benchmark. You may specify the number of apps in
-the cluster, the benchmark run time, and the requests per second via the
+the cluster, the benchmark run time, the requests per second, and the number of
+parallel connections / threads used by the benchmark load generator via the
 command line.
 
 The following example starts a linkerd benchmark running 5 minutes, with 10
-apps and a constant request rate of 100RPS:
-* `scripts/linkerd/benchmark.sh 10 5m 100`
+apps a constant request rate of 100RPS, using 8 load generator threads:
+* `scripts/linkerd/benchmark.sh 10 5m 100 8`
 
 If you want to run a full series of benchmarks for linkerd, istio stock, istio
 tuned, and bare, simply issue:
-* `scripts/linkerd/benchark-multi.sh 10 5m 100`
+* `scripts/linkerd/benchark-multi.sh 10 5m 100 8`
 
 Please note that you must always use scripts from the directory of your
 respective cluster service mesh. If your cluster currently has istio installed,

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -292,6 +292,7 @@ function run_benchmark() {
     local log_dir="${BENCHMARK_LOGFILE_DIR:-.}/"
     local duration=${4:-30m}
     local rate=${5:-800}
+    local threads=${6:-8}
 
     local script_dir=$(dirname ${BASH_SOURCE[0]})
     local template="${script_dir}/../wrk2/wrk2.yaml.tmpl"
@@ -300,7 +301,8 @@ function run_benchmark() {
 
     ${script_dir}/../wrk2/render.sh --instances $instances \
                                     --duration $duration \
-                                    --rate $rate > $deployment
+                                    --rate $rate \
+                                    --threads $threads > $deployment
 
     echo "Injecting service mesh via '$inject $deployment'"
     $inject $deployment > $deployment_injected

--- a/scripts/istio/benchmark.sh
+++ b/scripts/istio/benchmark.sh
@@ -14,11 +14,14 @@ duration="30m"
 rate="800"
 [ $# -ge 3 ] && rate="$3"
 
-istioctl=$(grok_cmd 4 "istioctl" $@)
+threads="8"
+[ $# -ge 4 ] && threads="$4"
+
+istioctl=$(grok_cmd 5 "istioctl" $@)
 [ -z $istioctl ] && { echo "Aborting."; exit 1; }
 
 istio_type="tuned"
-[ $# -ge 5 ] && istio_type="$5"
+[ $# -ge 6 ] && istio_type="$6"
 
 asset_dir="${script_dir}/../../assets"
 KUBECONFIG=$(print_kubeconfig_path "$asset_dir")
@@ -40,7 +43,7 @@ install_emojivoto "$istioctl kube-inject -f" $nr_apps
 echo "Sleeping for $((5*nr_apps)) seconds to let injected apps settle some more."
 sleep $((5*nr_apps))
 
-run_benchmark "istio-${istio_type}" $nr_apps "$istioctl kube-inject -f" "$duration" "$rate"
+run_benchmark "istio-${istio_type}" $nr_apps "$istioctl kube-inject -f" "$duration" "$rate" "$threads"
 
 echo "### Cleaning up..."
 kubectl delete -f emojivoto.injected.yaml --wait=true --grace-period=1 --all=true || true

--- a/scripts/linkerd/benchmark-multi.sh
+++ b/scripts/linkerd/benchmark-multi.sh
@@ -26,16 +26,19 @@ duration="30m"
 rate="800"
 [ $# -ge 3 ] && rate="$3"
 
-linkerd=$(grok_cmd 4 "linkerd2-cli-edge-19.5.3-linux" $@)
+threads="8"
+[ $# -ge 4 ] && threads="$4"
+
+linkerd=$(grok_cmd 5 "linkerd2-cli-edge-19.5.3-linux" $@)
 [ -z $linkerd ] && { echo "Aborting."; exit 1; }
 
-istioctl=$(grok_cmd 5 "istioctl" $@)
+istioctl=$(grok_cmd 6 "istioctl" $@)
 [ -z $istioctl ] && { echo "Aborting."; exit 1; }
 
 
 ###  Linkerd
 echo "##### Running $linkerd benchmark"
-${script_dir}/benchmark.sh $nr_apps $duration $rate $linkerd
+${script_dir}/benchmark.sh $nr_apps $duration $rate $threads $linkerd
 
 echo "##### Removing linkerd and installing istio tuned"
 ${script_dir}/cleanup-linkerd.sh
@@ -46,7 +49,7 @@ STOCK_MODE=0 ${script_dir}/../istio/setup-cluster.sh $istioctl
 
 echo
 echo "##### Running $istioctl benchmark (tuned)"
-${script_dir}/../istio/benchmark.sh $nr_apps $duration $rate $istioctl "tuned"
+${script_dir}/../istio/benchmark.sh $nr_apps $duration $rate $threads $istioctl "tuned"
 
 echo "##### Removing istio tuned and installing istio stock"
 ${script_dir}/../istio/cleanup-istio.sh
@@ -57,7 +60,7 @@ STOCK_MODE=1 ${script_dir}/../istio/setup-cluster.sh $istioctl
 
 echo
 echo "##### Running $istioctl benchmark (stock)"
-${script_dir}/../istio/benchmark.sh $nr_apps $duration $rate $istioctl "stock"
+${script_dir}/../istio/benchmark.sh $nr_apps $duration $rate $threads $istioctl "stock"
 
 echo "##### Removing istio"
 ${script_dir}/../istio/cleanup-istio.sh
@@ -71,7 +74,7 @@ taint_random_worker_node "$nr_apps" "reserved-for-benchmark-load-generator"
 install_emojivoto "cat" $nr_apps
 
 echo "##### Running bare benchmark"
-run_benchmark "bare" $nr_apps "cat" "$duration" "$rate"
+run_benchmark "bare" $nr_apps "cat" "$duration" "$rate" "$threads"
 
 echo "##### removing bare emojivoto"
 kubectl delete -f emojivoto.injected.yaml --wait=true --grace-period=1 --all=true || true

--- a/scripts/linkerd/benchmark.sh
+++ b/scripts/linkerd/benchmark.sh
@@ -14,7 +14,10 @@ duration="30m"
 rate="800"
 [ $# -ge 3 ] && rate="$3"
 
-linkerd=$(grok_cmd 4 "linkerd2-cli-edge-19.5.3-linux" $@)
+threads="8"
+[ $# -ge 4 ] && threads="$4"
+
+linkerd=$(grok_cmd 5 "linkerd2-cli-edge-19.5.3-linux" $@)
 [ -z $linkerd ] && { echo "Aborting."; exit 1; }
 
 asset_dir="${script_dir}/../../assets"
@@ -40,7 +43,7 @@ clear
 echo "Sleeping for $((5*nr_apps)) seconds to let injected apps settle some more."
 sleep $((5*nr_apps))
 
-run_benchmark "linkerd" $nr_apps "$linkerd inject --manual" "$duration" "$rate"
+run_benchmark "linkerd" $nr_apps "$linkerd inject --manual" "$duration" "$rate" "$threads"
 
 echo "### Cleaning up..."
 kubectl delete -f emojivoto.injected.yaml --wait=true --grace-period=1 --all=true || true

--- a/wrk2/render.sh
+++ b/wrk2/render.sh
@@ -8,6 +8,7 @@ export IMAGE=quay.io/kinvolk/wrk2:latest
 export DURATION=5m
 export RATE=1500
 export INSTANCES=8
+export THREADS=8
 
 usage() {
 	cat <<HELP_USAGE
@@ -20,6 +21,8 @@ Usage: $0 [OPTION...]
   -d, --duration  Duration of benchmark.
   -r, --rate      Requests per second for each instance.
   -I, --instances Number of instances.
+  -t, --threads   Number of parallel threads/connections to use.
+                  Each thread will use a single connection.
   -h  --help      Prints this message.
 HELP_USAGE
 }
@@ -49,6 +52,11 @@ case $key in
   ;;
   -I|--instances)
     export INSTANCES="$2"
+    shift # past argument
+    shift # past value
+  ;;
+  -t|--threads)
+    export THREADS="$2"
     shift # past argument
     shift # past value
   ;;

--- a/wrk2/wrk2.yaml.tmpl
+++ b/wrk2/wrk2.yaml.tmpl
@@ -188,9 +188,9 @@ spec:
         - -R
         - "${RATE}"
         - -c
-        - "${INSTANCES}"
+        - "${THREADS}"
         - -t
-        - "${INSTANCES}"
+        - "${THREADS}"
         - --latency
         - --timeout
         - "5000"


### PR DESCRIPTION
This change adds support for a --threads flag to `wrk2/render.sh`, and
adds the number of benchmark load generator threads to `benchmark.sh`
and `benchmark-multi.sh`.

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>