### PR TITLE
packet-cluster.lokocfg: adjust benchmark node to 1, app to 6

### DIFF
--- a/configs/packet-cluster.lokocfg
+++ b/configs/packet-cluster.lokocfg
@@ -37,13 +37,13 @@ cluster "packet" {
   }
 
   worker_pool "applications" {
-    count = 4
+    count = 6
     node_type = "n2.xlarge.x86"
   }
 
   # Reserved for the load generator
   worker_pool "loadgenerator" {
-    count = 2
+    count = 1
     node_type = "n2.xlarge.x86"
     taints = "load-generator-node=None:NoSchedule"
   }


### PR DESCRIPTION
We don't need multiple wrk2 nodes after the recent optimisations - this PR decreases the pool to use a single worker. Application nodes are bumped to 6 which should be closer to the amount we can saturate with wrk2.