### PR TITLE
bookinfo,emojivoto: Fix PSP to work with Istio

### DIFF
--- a/configs/bookinfo/templates/psp.yml
+++ b/configs/bookinfo/templates/psp.yml
@@ -1,15 +1,15 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: linkerd-bookinfo-data-plane-{{.Release.Name}}
+  name: bookinfo-data-plane-{{.Release.Name}}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:
     ranges:
     - max: 65535
-      min: 10001
+      min: 1337
     rule: MustRunAs
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
@@ -43,7 +43,7 @@ rules:
 - apiGroups: ['policy','extensions']
   resources: ['podsecuritypolicies']
   verbs: ['use']
-  resourceNames: ['linkerd-bookinfo-data-plane-{{.Release.Name}}']
+  resourceNames: ['bookinfo-data-plane-{{.Release.Name}}']
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/configs/emojivoto/templates/psp.yaml
+++ b/configs/emojivoto/templates/psp.yaml
@@ -1,15 +1,15 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: linkerd-emojivoto-data-plane-{{.Release.Name}}
+  name: emojivoto-data-plane-{{.Release.Name}}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:
     ranges:
     - max: 65535
-      min: 10001
+      min: 1337
     rule: MustRunAs
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
@@ -43,7 +43,7 @@ rules:
 - apiGroups: ['policy','extensions']
   resources: ['podsecuritypolicies']
   verbs: ['use']
-  resourceNames: ['linkerd-emojivoto-data-plane-{{.Release.Name}}']
+  resourceNames: ['emojivoto-data-plane-{{.Release.Name}}']
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
- Change the fsGroup's min to 1337.
- Allow filesystem to be writable.
- Remove the name prefix `linkerd` from PSP.