### PR TITLE
apps: add linkerd auto-inject annotations, remove emoji votebot

### DIFF
--- a/configs/bookinfo/templates/deployment.yaml
+++ b/configs/bookinfo/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         app: details
         version: v1
@@ -46,6 +48,8 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         app: ratings
         version: v1
@@ -78,6 +82,8 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         app: reviews
         version: v1
@@ -119,6 +125,8 @@ spec:
       version: v2
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         app: reviews
         version: v2
@@ -160,6 +168,8 @@ spec:
       version: v3
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         app: reviews
         version: v3
@@ -201,6 +211,8 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         app: productpage
         version: v1

--- a/configs/emojivoto/templates/deployment.yaml
+++ b/configs/emojivoto/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       app: emoji-svc
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         app: emoji-svc
     spec:
@@ -43,41 +45,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/name: vote-bot
-    app.kubernetes.io/part-of: emojivoto
-    app.kubernetes.io/version: v10
-  name: vote-bot
-  namespace: {{.Release.Namespace}}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: vote-bot
-  template:
-    metadata:
-      labels:
-        app: vote-bot
-    spec:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
-      containers:
-      - command:
-        - emojivoto-vote-bot
-        env:
-        - name: WEB_HOST
-          value: web-svc.{{.Release.Namespace}}:80
-        image: buoyantio/emojivoto-web:v10
-        name: vote-bot
-        resources:
-          requests:
-            cpu: 10m
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
     app.kubernetes.io/name: voting
     app.kubernetes.io/part-of: emojivoto
     app.kubernetes.io/version: v10
@@ -90,6 +57,8 @@ spec:
       app: voting-svc
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         app: voting-svc
     spec:
@@ -131,6 +100,8 @@ spec:
       app: web-svc
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         app: web-svc
     spec:


### PR DESCRIPTION
This PR adds annotations to auto-inject linkerd sidecars to emojivoto and bookinfo applications. Furthermore, it removes the "votebot" service from the emojivoto deployments - "votebot" is a demo service that just generates traffic and is not required for the benchmark.

# How to test
- install linkerd: `lokoctl component apply experimental-linkerd`
- deploy e.g. emojivoto: `helm install --create-namespace emojivoto --namespace emojivoto configs/emojivoto/`
- open the linkerd hashboard: `linkerd2-cli dashboard`, open the url `namespaces/emojivoto`. You should see all three "emoji", "voting", and "web" deployments having 1/1 in the "Meshed" column.

Before applying this PR, the "Meshed" status would be 0/1.