### PR TITLE
wrk2.yaml: add linkerd sidecar injection annotation

### DIFF
--- a/configs/benchmark/templates/wrk2.yaml
+++ b/configs/benchmark/templates/wrk2.yaml
@@ -9,6 +9,8 @@ spec:
   template:
     metadata:
       name: wrk2-prometheus
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         jobgroup: wrk2-prometheus
         app: wrk2-prometheus


### PR DESCRIPTION
We were missing linkerd auto-injection annotations for wrk2. This PR adds the annotation to the helm charts.