### PR TITLE
benchmark: add init delay

### DIFF
--- a/configs/benchmark/templates/wrk2.yaml
+++ b/configs/benchmark/templates/wrk2.yaml
@@ -50,6 +50,8 @@ spec:
         - "{{.Values.wrk2.duration}}"
         - -r
         - "{{.Values.wrk2.RPS}}"
+        - -i
+        - "{{.Values.wrk2.initDelay}}"
 {{- if eq .Values.wrk2.app.name "emojivoto" }}
 {{- template "emojivotoURLs" . }}
 {{- else if eq .Values.wrk2.app.name "bookinfo" }}

--- a/configs/benchmark/values.yaml
+++ b/configs/benchmark/values.yaml
@@ -2,6 +2,7 @@ wrk2:
   duration: 120
   connections: 96
   RPS: 3000
+  initDelay: 0
   serviceMesh: ""
   app:
     name: emojivoto

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -78,12 +78,14 @@ function run_bench() {
             --set wrk2.RPS="$rps" \
             --set wrk2.duration=600 \
             --set wrk2.connections=128 \
+            --set wrk2.initDelay=60 \
             ${script_location}/../configs/benchmark/
     else
         helm install benchmark --namespace benchmark \
             --set wrk2.app.count="$app_count" \
             --set wrk2.RPS="$rps" \
             --set wrk2.duration=600 \
+            --set wrk2.initDelay=60 \
             --set wrk2.connections=128 \
             ${script_location}/../configs/benchmark/
     fi
@@ -91,8 +93,8 @@ function run_bench() {
     while kubectl get jobs -n benchmark \
             | grep wrk2-prometheus \
             | grep -qv 1/1; do
-        kubectl logs --tail 1 -n benchmark \
-                                        jobs/wrk2-prometheus -c wrk2-prometheus
+        kubectl logs \
+                --tail 1 -n benchmark  jobs/wrk2-prometheus -c wrk2-prometheus
         sleep 10
     done
 
@@ -119,7 +121,7 @@ function run_bench() {
 # --
 
 function run_benchmarks() {
-    for rps in 500 1000 1500 2500 3000 3500 4000 4500 5000; do
+    for rps in 500 750 1000 1250 1500 2000 2500 3000 4000 5000 8000 10000; do
         for repeat in 1 2 3; do
 
             echo "########## Run #$repeat w/ $rps RPS"


### PR DESCRIPTION
Adds the new [wrk2 prometheus container init delay option](https://github.com/kinvolk/wrk2/pull/13) to the benchmark helm chart.