### PR TITLE
fix summary dashboard links

### DIFF
--- a/dashboards/grafana-wrk2-summary.json
+++ b/dashboards/grafana-wrk2-summary.json
@@ -8,10 +8,10 @@
     "slug": "wrk2-summary",
     "expires": "0001-01-01T00:00:00Z",
     "created": "2020-07-25T15:25:31Z",
-    "updated": "2020-07-27T10:57:13Z",
+    "updated": "2020-07-27T16:38:24Z",
     "updatedBy": "admin",
     "createdBy": "Anonymous",
-    "version": 7,
+    "version": 10,
     "hasAcl": false,
     "isFolder": false,
     "folderId": 0,
@@ -38,19 +38,2438 @@
     "gnetId": null,
     "graphTooltip": 0,
     "id": 27,
-    "iteration": 1595746681028,
+    "iteration": 1595860912655,
     "links": [],
     "panels": [
       {
-        "content": "<h3><center>Bare metal latency percentiles</center></h3>",
+        "content": "<h1><center>Benchmark latency summary</center></h1>\n<hr>\n<h3><center>Bare Metal, Linkerd, and Istio compared</center></h3>",
         "datasource": null,
         "gridPos": {
-          "h": 2,
-          "w": 22,
+          "h": 3,
+          "w": 24,
           "x": 0,
           "y": 0
         },
+        "id": 44,
+        "mode": "html",
+        "options": {},
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "content": "<br />\n<center><b>0.5 percentile</b></center>",
+        "datasource": null,
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 0,
+          "y": 3
+        },
         "id": 12,
+        "mode": "html",
+        "options": {},
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "content": "<br />\n<center><b>0.75 percentile</b></center>",
+        "datasource": null,
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 3,
+          "y": 3
+        },
+        "id": 36,
+        "mode": "html",
+        "options": {},
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "content": "<br />\n<center><b>0.9 percentile</b></center>",
+        "datasource": null,
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 6,
+          "y": 3
+        },
+        "id": 37,
+        "mode": "html",
+        "options": {},
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "content": "<br />\n<center><b>0.99 percentile</b></center>",
+        "datasource": null,
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 9,
+          "y": 3
+        },
+        "id": 38,
+        "mode": "html",
+        "options": {},
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "content": "<br />\n<center><b>0.999 percentile</b></center>",
+        "datasource": null,
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 12,
+          "y": 3
+        },
+        "id": 43,
+        "mode": "html",
+        "options": {},
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "content": "<br />\n<center><b>0.9999 percentile</b></center>",
+        "datasource": null,
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 15,
+          "y": 3
+        },
+        "id": 41,
+        "mode": "html",
+        "options": {},
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "content": "<br />\n<center><b>0.99999 percentile</b></center>",
+        "datasource": null,
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 18,
+          "y": 3
+        },
+        "id": 40,
+        "mode": "html",
+        "options": {},
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "content": "<br />\n<center><b>1.0 percentile</b></center>",
+        "datasource": null,
+        "gridPos": {
+          "h": 2,
+          "w": 3,
+          "x": 21,
+          "y": 3
+        },
+        "id": 39,
+        "mode": "html",
+        "options": {},
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 0,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.5\",exported_job=\"bare-metal\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "bare",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 1,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 14,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.5\",exported_job=\"svcmesh-linkerd\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "linkerd",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 2,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 23,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.5\",exported_job=\"svcmesh-istio\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "istio",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 3,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 3,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.75\",exported_job=\"bare-metal\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "bare",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 4,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 15,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.75\",exported_job=\"svcmesh-linkerd\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "linkerd",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 5,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 24,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.75\",exported_job=\"svcmesh-istio\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "istio",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 6,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 5,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.9\",exported_job=\"bare-metal\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "bare",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 7,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 16,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.9\",exported_job=\"svcmesh-linkerd\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "linkerd",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 8,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 25,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.9\",exported_job=\"svcmesh-istio\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "istio",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 9,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 4,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.99\",exported_job=\"bare-metal\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "bare",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 10,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 17,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.99\",exported_job=\"svcmesh-linkerd\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "linkerd",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 11,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 26,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.99\",exported_job=\"svcmesh-istio\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "istio",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 12,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 7,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.999\",exported_job=\"bare-metal\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "bare",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 13,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 18,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.999\",exported_job=\"svcmesh-linkerd\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "linkerd",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 14,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 27,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.999\",exported_job=\"svcmesh-istio\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "istio",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 15,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 6,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.9999\",exported_job=\"bare-metal\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "bare",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 16,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 19,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.9999\",exported_job=\"svcmesh-linkerd\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "linkerd",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 17,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 28,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.9999\",exported_job=\"svcmesh-istio\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "istio",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 18,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 9,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.99999\",exported_job=\"bare-metal\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "bare",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 19,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 20,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.99999\",exported_job=\"svcmesh-linkerd\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "linkerd",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 20,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 29,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"0.99999\",exported_job=\"svcmesh-istio\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "istio",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 21,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 8,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 0,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 0.5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"1.0\",exported_job=\"bare-metal\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "bare",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 22,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 21,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"1.0\",exported_job=\"svcmesh-linkerd\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "linkerd",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fill": 3,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 1,
+          "x": 23,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 30,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": false,
+          "min": false,
+          "rightSide": false,
+          "show": false,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null as zero",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.5.0",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "wrk2_benchmark_summary_latency_ms{requested_rps=\"$rps\",p=\"1.0\",exported_job=\"svcmesh-istio\"}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Run {{source_run}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "istio",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "individual"
+        },
+        "transparent": true,
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": false,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 2,
+            "max": "10000",
+            "min": "0",
+            "show": false
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "content": "<hr>\n<h3><center>Bare Metal latency percentiles</center>",
+        "datasource": null,
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 14
+        },
+        "id": 63,
         "mode": "html",
         "options": {},
         "timeFrom": null,
@@ -72,10 +2491,10 @@
           "h": 9,
           "w": 2,
           "x": 0,
-          "y": 2
+          "y": 16
         },
         "hiddenSeries": false,
-        "id": 2,
+        "id": 45,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -166,10 +2585,10 @@
           "h": 9,
           "w": 2,
           "x": 2,
-          "y": 2
+          "y": 16
         },
         "hiddenSeries": false,
-        "id": 3,
+        "id": 46,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -260,10 +2679,10 @@
           "h": 9,
           "w": 2,
           "x": 4,
-          "y": 2
+          "y": 16
         },
         "hiddenSeries": false,
-        "id": 5,
+        "id": 48,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -354,10 +2773,10 @@
           "h": 9,
           "w": 2,
           "x": 6,
-          "y": 2
+          "y": 16
         },
         "hiddenSeries": false,
-        "id": 4,
+        "id": 47,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -448,10 +2867,10 @@
           "h": 9,
           "w": 2,
           "x": 8,
-          "y": 2
+          "y": 16
         },
         "hiddenSeries": false,
-        "id": 7,
+        "id": 49,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -542,10 +2961,10 @@
           "h": 9,
           "w": 2,
           "x": 10,
-          "y": 2
+          "y": 16
         },
         "hiddenSeries": false,
-        "id": 6,
+        "id": 50,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -636,10 +3055,10 @@
           "h": 9,
           "w": 2,
           "x": 12,
-          "y": 2
+          "y": 16
         },
         "hiddenSeries": false,
-        "id": 9,
+        "id": 51,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -730,10 +3149,10 @@
           "h": 9,
           "w": 2,
           "x": 14,
-          "y": 2
+          "y": 16
         },
         "hiddenSeries": false,
-        "id": 8,
+        "id": 52,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -745,7 +3164,7 @@
           "values": true
         },
         "lines": true,
-        "linewidth": 0,
+        "linewidth": 1,
         "links": [],
         "nullPointMode": "null as zero",
         "options": {
@@ -753,7 +3172,7 @@
         },
         "percentage": false,
         "pluginVersion": "6.5.0",
-        "pointradius": 0.5,
+        "pointradius": 2,
         "points": false,
         "renderer": "flot",
         "seriesOverrides": [],
@@ -816,10 +3235,10 @@
         "datasource": "Prometheus",
         "fontSize": "100%",
         "gridPos": {
-          "h": 11,
-          "w": 6,
+          "h": 9,
+          "w": 8,
           "x": 16,
-          "y": 2
+          "y": 16
         },
         "id": 33,
         "options": {},
@@ -905,15 +3324,15 @@
         "type": "table"
       },
       {
-        "content": "<hr>\n<h3><center>Linkerd latency percentiles</center></h3>",
+        "content": "<hr>\n<h3><center>Linkerd latency percentiles</center>",
         "datasource": null,
         "gridPos": {
           "h": 2,
-          "w": 22,
+          "w": 24,
           "x": 0,
-          "y": 13
+          "y": 25
         },
-        "id": 13,
+        "id": 62,
         "mode": "html",
         "options": {},
         "timeFrom": null,
@@ -935,10 +3354,10 @@
           "h": 9,
           "w": 2,
           "x": 0,
-          "y": 15
+          "y": 27
         },
         "hiddenSeries": false,
-        "id": 14,
+        "id": 54,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1029,10 +3448,10 @@
           "h": 9,
           "w": 2,
           "x": 2,
-          "y": 15
+          "y": 27
         },
         "hiddenSeries": false,
-        "id": 15,
+        "id": 55,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1123,10 +3542,10 @@
           "h": 9,
           "w": 2,
           "x": 4,
-          "y": 15
+          "y": 27
         },
         "hiddenSeries": false,
-        "id": 16,
+        "id": 56,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1217,10 +3636,10 @@
           "h": 9,
           "w": 2,
           "x": 6,
-          "y": 15
+          "y": 27
         },
         "hiddenSeries": false,
-        "id": 17,
+        "id": 57,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1311,10 +3730,10 @@
           "h": 9,
           "w": 2,
           "x": 8,
-          "y": 15
+          "y": 27
         },
         "hiddenSeries": false,
-        "id": 18,
+        "id": 58,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1405,10 +3824,10 @@
           "h": 9,
           "w": 2,
           "x": 10,
-          "y": 15
+          "y": 27
         },
         "hiddenSeries": false,
-        "id": 19,
+        "id": 59,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1499,10 +3918,10 @@
           "h": 9,
           "w": 2,
           "x": 12,
-          "y": 15
+          "y": 27
         },
         "hiddenSeries": false,
-        "id": 20,
+        "id": 60,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1593,10 +4012,10 @@
           "h": 9,
           "w": 2,
           "x": 14,
-          "y": 15
+          "y": 27
         },
         "hiddenSeries": false,
-        "id": 21,
+        "id": 61,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1679,10 +4098,10 @@
         "datasource": "Prometheus",
         "fontSize": "100%",
         "gridPos": {
-          "h": 11,
-          "w": 6,
+          "h": 9,
+          "w": 8,
           "x": 16,
-          "y": 15
+          "y": 27
         },
         "id": 34,
         "options": {},
@@ -1768,15 +4187,15 @@
         "type": "table"
       },
       {
-        "content": "<hr>\n<h3><center>Istio latency percentiles</center></h3>",
+        "content": "<hr>\n<h3><center>Istio latency percentiles</center>",
         "datasource": null,
         "gridPos": {
           "h": 2,
-          "w": 22,
+          "w": 24,
           "x": 0,
-          "y": 26
+          "y": 36
         },
-        "id": 22,
+        "id": 53,
         "mode": "html",
         "options": {},
         "timeFrom": null,
@@ -1798,10 +4217,10 @@
           "h": 9,
           "w": 2,
           "x": 0,
-          "y": 28
+          "y": 38
         },
         "hiddenSeries": false,
-        "id": 23,
+        "id": 64,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1892,10 +4311,10 @@
           "h": 9,
           "w": 2,
           "x": 2,
-          "y": 28
+          "y": 38
         },
         "hiddenSeries": false,
-        "id": 24,
+        "id": 65,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -1986,10 +4405,10 @@
           "h": 9,
           "w": 2,
           "x": 4,
-          "y": 28
+          "y": 38
         },
         "hiddenSeries": false,
-        "id": 25,
+        "id": 72,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -2080,10 +4499,10 @@
           "h": 9,
           "w": 2,
           "x": 6,
-          "y": 28
+          "y": 38
         },
         "hiddenSeries": false,
-        "id": 26,
+        "id": 67,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -2174,10 +4593,10 @@
           "h": 9,
           "w": 2,
           "x": 8,
-          "y": 28
+          "y": 38
         },
         "hiddenSeries": false,
-        "id": 27,
+        "id": 71,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -2268,10 +4687,10 @@
           "h": 9,
           "w": 2,
           "x": 10,
-          "y": 28
+          "y": 38
         },
         "hiddenSeries": false,
-        "id": 28,
+        "id": 73,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -2362,10 +4781,10 @@
           "h": 9,
           "w": 2,
           "x": 12,
-          "y": 28
+          "y": 38
         },
         "hiddenSeries": false,
-        "id": 29,
+        "id": 74,
         "legend": {
           "alignAsTable": true,
           "avg": false,
@@ -2456,17 +4875,16 @@
           "h": 9,
           "w": 2,
           "x": 14,
-          "y": 28
+          "y": 38
         },
         "hiddenSeries": false,
-        "id": 30,
+        "id": 75,
         "legend": {
           "alignAsTable": true,
           "avg": false,
           "current": true,
           "max": false,
           "min": false,
-          "rightSide": false,
           "show": false,
           "total": false,
           "values": true
@@ -2543,10 +4961,10 @@
         "datasource": "Prometheus",
         "fontSize": "100%",
         "gridPos": {
-          "h": 9,
-          "w": 6,
+          "h": 8,
+          "w": 8,
           "x": 16,
-          "y": 28
+          "y": 38
         },
         "id": 35,
         "options": {},
@@ -2686,6 +5104,6 @@
     "timezone": "",
     "title": "wrk2 Summary",
     "uid": null,
-    "version": 7
+    "version": 10
   }
 }

--- a/dashboards/grafana-wrk2-summary.json
+++ b/dashboards/grafana-wrk2-summary.json
@@ -7,11 +7,11 @@
     "canStar": true,
     "slug": "wrk2-summary",
     "expires": "0001-01-01T00:00:00Z",
-    "created": "2020-07-23T17:20:59Z",
-    "updated": "2020-07-24T13:32:39Z",
+    "created": "2020-07-25T15:25:31Z",
+    "updated": "2020-07-27T10:57:13Z",
     "updatedBy": "admin",
     "createdBy": "Anonymous",
-    "version": 30,
+    "version": 7,
     "hasAcl": false,
     "isFolder": false,
     "folderId": 0,
@@ -37,8 +37,8 @@
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "id": 26,
-    "iteration": 1595596839869,
+    "id": 27,
+    "iteration": 1595746681028,
     "links": [],
     "panels": [
       {
@@ -46,7 +46,7 @@
         "datasource": null,
         "gridPos": {
           "h": 2,
-          "w": 16,
+          "w": 22,
           "x": 0,
           "y": 0
         },
@@ -58,173 +58,6 @@
         "title": "",
         "transparent": true,
         "type": "text"
-      },
-      {
-        "columns": [],
-        "datasource": "Prometheus",
-        "fontSize": "100%",
-        "gridPos": {
-          "h": 11,
-          "w": 4,
-          "x": 16,
-          "y": 0
-        },
-        "id": 33,
-        "options": {},
-        "pageSize": null,
-        "showHeader": true,
-        "sort": {
-          "col": 2,
-          "desc": true
-        },
-        "styles": [
-          {
-            "alias": "benchmark run",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD_HH:mm:ss",
-            "decimals": 2,
-            "link": false,
-            "linkTargetBlank": true,
-            "linkTooltip": "Go to run ${__cell_2}.",
-            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=bare-metal&var-instance=${__cell_1}&var-run=${__cell_2}&time=${__cell_3}&time.window=1500000",
-            "mappingType": 1,
-            "pattern": "source_run",
-            "thresholds": [],
-            "type": "number",
-            "unit": "dateTimeAsIso",
-            "valueMaps": []
-          },
-          {
-            "alias": "",
-            "colorMode": "value",
-            "colors": [
-              "rgba(50, 172, 45, 0.97)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(245, 54, 54, 0.9)"
-            ],
-            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-            "decimals": 2,
-            "mappingType": 1,
-            "pattern": "Value",
-            "thresholds": [
-              "500",
-              "5000"
-            ],
-            "type": "number",
-            "unit": "ms"
-          },
-          {
-            "alias": "",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-            "decimals": 2,
-            "mappingType": 1,
-            "pattern": "(Time|exported_instance)",
-            "thresholds": [],
-            "type": "hidden",
-            "unit": "short"
-          }
-        ],
-        "targets": [
-          {
-            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"bare-metal\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,source_run,value)",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Peak latencies (1.0 percentile)",
-        "transform": "table",
-        "transparent": true,
-        "type": "table"
-      },
-      {
-        "columns": [],
-        "datasource": "Prometheus",
-        "fontSize": "100%",
-        "gridPos": {
-          "h": 11,
-          "w": 3,
-          "x": 20,
-          "y": 0
-        },
-        "id": 32,
-        "options": {},
-        "pageSize": null,
-        "showHeader": true,
-        "sort": {
-          "col": 2,
-          "desc": true
-        },
-        "styles": [
-          {
-            "alias": "cockpit link",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD_HH:mm:ss",
-            "decimals": 2,
-            "link": true,
-            "linkTargetBlank": true,
-            "linkTooltip": "Go to run ${__cell_2}.",
-            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=bare-metal&var-instance=${__cell_1}&var-run=${__cell_2}&time=${__cell_3}&time.window=1500000",
-            "mappingType": 1,
-            "pattern": "source_run",
-            "thresholds": [],
-            "type": "string",
-            "unit": "dateTimeAsIso",
-            "valueMaps": []
-          },
-          {
-            "alias": "",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-            "decimals": 2,
-            "mappingType": 1,
-            "pattern": "(Time|exported_instance|Value)",
-            "thresholds": [],
-            "type": "hidden",
-            "unit": "short"
-          }
-        ],
-        "targets": [
-          {
-            "expr": "count(wrk2_benchmark_summary_latency_ms{exported_job=\"bare-metal\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,source_run) * 0 + on(source_run) group_left() label_replace(wrk2_benchmark_run_runtime{exported_job=\"bare-metal\",kind=\"end\"},\"source_run\", \"$1\", \"run\", \"(.*)\")*1000",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Drill down",
-        "transform": "table",
-        "transparent": true,
-        "type": "table"
       },
       {
         "aliasColors": {},
@@ -979,44 +812,26 @@
         }
       },
       {
-        "content": "<hr>\n<h3><center>Linkerd latency percentiles</center></h3>",
-        "datasource": null,
-        "gridPos": {
-          "h": 2,
-          "w": 16,
-          "x": 0,
-          "y": 11
-        },
-        "id": 13,
-        "mode": "html",
-        "options": {},
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "",
-        "transparent": true,
-        "type": "text"
-      },
-      {
         "columns": [],
         "datasource": "Prometheus",
         "fontSize": "100%",
         "gridPos": {
           "h": 11,
-          "w": 4,
+          "w": 6,
           "x": 16,
-          "y": 11
+          "y": 2
         },
-        "id": 34,
+        "id": 33,
         "options": {},
         "pageSize": null,
         "showHeader": true,
         "sort": {
-          "col": 2,
+          "col": 4,
           "desc": true
         },
         "styles": [
           {
-            "alias": "benchmark run",
+            "alias": "benchmark run (click to open in cockpit)",
             "colorMode": null,
             "colors": [
               "rgba(245, 54, 54, 0.9)",
@@ -1025,10 +840,10 @@
             ],
             "dateFormat": "YYYY-MM-DD_HH:mm:ss",
             "decimals": 2,
-            "link": false,
+            "link": true,
             "linkTargetBlank": true,
-            "linkTooltip": "Go to run ${__cell_2}.",
-            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=bare-metal&var-instance=${__cell_1}&var-run=${__cell_2}&time=${__cell_3}&time.window=1500000",
+            "linkTooltip": "Go to run ${__cell_3}.",
+            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=bare-metal&var-instance=${__cell_2}&var-run=${__cell_3}&time=${__cell_1}&time.window=1500000",
             "mappingType": 1,
             "pattern": "source_run",
             "thresholds": [],
@@ -1066,7 +881,7 @@
             "dateFormat": "YYYY-MM-DD HH:mm:ss",
             "decimals": 2,
             "mappingType": 1,
-            "pattern": "(Time|exported_instance)",
+            "pattern": "(Time|exported_instance|end)",
             "thresholds": [],
             "type": "hidden",
             "unit": "short"
@@ -1074,7 +889,7 @@
         ],
         "targets": [
           {
-            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-linkerd\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,source_run,value)",
+            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"bare-metal\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,end,source_run,value)",
             "format": "table",
             "hide": false,
             "instant": true,
@@ -1090,78 +905,22 @@
         "type": "table"
       },
       {
-        "columns": [],
-        "datasource": "Prometheus",
-        "fontSize": "100%",
+        "content": "<hr>\n<h3><center>Linkerd latency percentiles</center></h3>",
+        "datasource": null,
         "gridPos": {
-          "h": 11,
-          "w": 3,
-          "x": 20,
-          "y": 11
+          "h": 2,
+          "w": 22,
+          "x": 0,
+          "y": 13
         },
-        "id": 35,
+        "id": 13,
+        "mode": "html",
         "options": {},
-        "pageSize": null,
-        "showHeader": true,
-        "sort": {
-          "col": 2,
-          "desc": true
-        },
-        "styles": [
-          {
-            "alias": "cockpit link",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD_HH:mm:ss",
-            "decimals": 2,
-            "link": true,
-            "linkTargetBlank": true,
-            "linkTooltip": "Go to run ${__cell_2}.",
-            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=svcmesh-linkerd&var-instance=${__cell_1}&var-run=${__cell_2}&time=${__cell_3}&time.window=1500000",
-            "mappingType": 1,
-            "pattern": "source_run",
-            "thresholds": [],
-            "type": "number",
-            "unit": "dateTimeAsIso",
-            "valueMaps": []
-          },
-          {
-            "alias": "",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-            "decimals": 2,
-            "mappingType": 1,
-            "pattern": "(Time|exported_instance|Value)",
-            "thresholds": [],
-            "type": "hidden",
-            "unit": "short"
-          }
-        ],
-        "targets": [
-          {
-            "expr": "count(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-linkerd\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,source_run) * 0 + on(source_run) group_left() label_replace(wrk2_benchmark_run_runtime{exported_job=\"svcmesh-linkerd\",kind=\"end\"},\"source_run\", \"$1\", \"run\", \"(.*)\")*1000",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
         "timeFrom": null,
         "timeShift": null,
-        "title": "Drill down",
-        "transform": "table",
+        "title": "",
         "transparent": true,
-        "type": "table"
+        "type": "text"
       },
       {
         "aliasColors": {},
@@ -1176,7 +935,7 @@
           "h": 9,
           "w": 2,
           "x": 0,
-          "y": 13
+          "y": 15
         },
         "hiddenSeries": false,
         "id": 14,
@@ -1270,7 +1029,7 @@
           "h": 9,
           "w": 2,
           "x": 2,
-          "y": 13
+          "y": 15
         },
         "hiddenSeries": false,
         "id": 15,
@@ -1364,7 +1123,7 @@
           "h": 9,
           "w": 2,
           "x": 4,
-          "y": 13
+          "y": 15
         },
         "hiddenSeries": false,
         "id": 16,
@@ -1458,7 +1217,7 @@
           "h": 9,
           "w": 2,
           "x": 6,
-          "y": 13
+          "y": 15
         },
         "hiddenSeries": false,
         "id": 17,
@@ -1552,7 +1311,7 @@
           "h": 9,
           "w": 2,
           "x": 8,
-          "y": 13
+          "y": 15
         },
         "hiddenSeries": false,
         "id": 18,
@@ -1646,7 +1405,7 @@
           "h": 9,
           "w": 2,
           "x": 10,
-          "y": 13
+          "y": 15
         },
         "hiddenSeries": false,
         "id": 19,
@@ -1740,7 +1499,7 @@
           "h": 9,
           "w": 2,
           "x": 12,
-          "y": 13
+          "y": 15
         },
         "hiddenSeries": false,
         "id": 20,
@@ -1834,7 +1593,7 @@
           "h": 9,
           "w": 2,
           "x": 14,
-          "y": 13
+          "y": 15
         },
         "hiddenSeries": false,
         "id": 21,
@@ -1916,44 +1675,26 @@
         }
       },
       {
-        "content": "<hr>\n<h3><center>Istio latency percentiles</center></h3>",
-        "datasource": null,
-        "gridPos": {
-          "h": 2,
-          "w": 16,
-          "x": 0,
-          "y": 22
-        },
-        "id": 22,
-        "mode": "html",
-        "options": {},
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "",
-        "transparent": true,
-        "type": "text"
-      },
-      {
         "columns": [],
         "datasource": "Prometheus",
         "fontSize": "100%",
         "gridPos": {
           "h": 11,
-          "w": 4,
+          "w": 6,
           "x": 16,
-          "y": 22
+          "y": 15
         },
-        "id": 36,
+        "id": 34,
         "options": {},
         "pageSize": null,
         "showHeader": true,
         "sort": {
-          "col": 2,
+          "col": 4,
           "desc": true
         },
         "styles": [
           {
-            "alias": "benchmark run",
+            "alias": "benchmark run (click to open in cockpit)",
             "colorMode": null,
             "colors": [
               "rgba(245, 54, 54, 0.9)",
@@ -1962,10 +1703,10 @@
             ],
             "dateFormat": "YYYY-MM-DD_HH:mm:ss",
             "decimals": 2,
-            "link": false,
+            "link": true,
             "linkTargetBlank": true,
-            "linkTooltip": "Go to run ${__cell_2}.",
-            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=bare-metal&var-instance=${__cell_1}&var-run=${__cell_2}&time=${__cell_3}&time.window=1500000",
+            "linkTooltip": "Go to run ${__cell_3}.",
+            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=svcmesh-linkerd&var-instance=${__cell_2}&var-run=${__cell_3}&time=${__cell_1}&time.window=1500000",
             "mappingType": 1,
             "pattern": "source_run",
             "thresholds": [],
@@ -2003,7 +1744,7 @@
             "dateFormat": "YYYY-MM-DD HH:mm:ss",
             "decimals": 2,
             "mappingType": 1,
-            "pattern": "(Time|exported_instance)",
+            "pattern": "(Time|exported_instance|end)",
             "thresholds": [],
             "type": "hidden",
             "unit": "short"
@@ -2011,7 +1752,7 @@
         ],
         "targets": [
           {
-            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-istio\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,source_run,value)",
+            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-linkerd\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,end,source_run,value)",
             "format": "table",
             "hide": false,
             "instant": true,
@@ -2027,78 +1768,22 @@
         "type": "table"
       },
       {
-        "columns": [],
-        "datasource": "Prometheus",
-        "fontSize": "100%",
+        "content": "<hr>\n<h3><center>Istio latency percentiles</center></h3>",
+        "datasource": null,
         "gridPos": {
-          "h": 11,
-          "w": 3,
-          "x": 20,
-          "y": 22
+          "h": 2,
+          "w": 22,
+          "x": 0,
+          "y": 26
         },
-        "id": 37,
+        "id": 22,
+        "mode": "html",
         "options": {},
-        "pageSize": null,
-        "showHeader": true,
-        "sort": {
-          "col": 2,
-          "desc": true
-        },
-        "styles": [
-          {
-            "alias": "cockpit link",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD_HH:mm:ss",
-            "decimals": 2,
-            "link": true,
-            "linkTargetBlank": true,
-            "linkTooltip": "Go to run ${__cell_2}.",
-            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=svcmesh-istio&var-instance=${__cell_1}&var-run=${__cell_2}&time=${__cell_3}&time.window=1500000",
-            "mappingType": 1,
-            "pattern": "source_run",
-            "thresholds": [],
-            "type": "number",
-            "unit": "dateTimeAsIso",
-            "valueMaps": []
-          },
-          {
-            "alias": "",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-            "decimals": 2,
-            "mappingType": 1,
-            "pattern": "(Time|exported_instance|Value)",
-            "thresholds": [],
-            "type": "hidden",
-            "unit": "short"
-          }
-        ],
-        "targets": [
-          {
-            "expr": "count(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-istio\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,source_run) * 0 + on(source_run) group_left() label_replace(wrk2_benchmark_run_runtime{exported_job=\"svcmesh-istio\",kind=\"end\"},\"source_run\", \"$1\", \"run\", \"(.*)\")*1000",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
         "timeFrom": null,
         "timeShift": null,
-        "title": "Drill down",
-        "transform": "table",
+        "title": "",
         "transparent": true,
-        "type": "table"
+        "type": "text"
       },
       {
         "aliasColors": {},
@@ -2113,7 +1798,7 @@
           "h": 9,
           "w": 2,
           "x": 0,
-          "y": 24
+          "y": 28
         },
         "hiddenSeries": false,
         "id": 23,
@@ -2207,7 +1892,7 @@
           "h": 9,
           "w": 2,
           "x": 2,
-          "y": 24
+          "y": 28
         },
         "hiddenSeries": false,
         "id": 24,
@@ -2301,7 +1986,7 @@
           "h": 9,
           "w": 2,
           "x": 4,
-          "y": 24
+          "y": 28
         },
         "hiddenSeries": false,
         "id": 25,
@@ -2395,7 +2080,7 @@
           "h": 9,
           "w": 2,
           "x": 6,
-          "y": 24
+          "y": 28
         },
         "hiddenSeries": false,
         "id": 26,
@@ -2489,7 +2174,7 @@
           "h": 9,
           "w": 2,
           "x": 8,
-          "y": 24
+          "y": 28
         },
         "hiddenSeries": false,
         "id": 27,
@@ -2583,7 +2268,7 @@
           "h": 9,
           "w": 2,
           "x": 10,
-          "y": 24
+          "y": 28
         },
         "hiddenSeries": false,
         "id": 28,
@@ -2677,7 +2362,7 @@
           "h": 9,
           "w": 2,
           "x": 12,
-          "y": 24
+          "y": 28
         },
         "hiddenSeries": false,
         "id": 29,
@@ -2771,7 +2456,7 @@
           "h": 9,
           "w": 2,
           "x": 14,
-          "y": 24
+          "y": 28
         },
         "hiddenSeries": false,
         "id": 30,
@@ -2852,6 +2537,99 @@
           "align": false,
           "alignLevel": null
         }
+      },
+      {
+        "columns": [],
+        "datasource": "Prometheus",
+        "fontSize": "100%",
+        "gridPos": {
+          "h": 9,
+          "w": 6,
+          "x": 16,
+          "y": 28
+        },
+        "id": 35,
+        "options": {},
+        "pageSize": null,
+        "showHeader": true,
+        "sort": {
+          "col": 2,
+          "desc": true
+        },
+        "styles": [
+          {
+            "alias": "benchmark run (click to open in cockpit)",
+            "colorMode": null,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD_HH:mm:ss",
+            "decimals": 2,
+            "link": true,
+            "linkTargetBlank": true,
+            "linkTooltip": "Go to run ${__cell_3}.",
+            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=svcmesh-istio&var-instance=${__cell_2}&var-run=${__cell_3}&time=${__cell_1}&time.window=1500000",
+            "mappingType": 1,
+            "pattern": "source_run",
+            "thresholds": [],
+            "type": "number",
+            "unit": "dateTimeAsIso",
+            "valueMaps": []
+          },
+          {
+            "alias": "",
+            "colorMode": "value",
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 2,
+            "mappingType": 1,
+            "pattern": "Value",
+            "thresholds": [
+              "500",
+              "5000"
+            ],
+            "type": "number",
+            "unit": "ms"
+          },
+          {
+            "alias": "",
+            "colorMode": null,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 2,
+            "mappingType": 1,
+            "pattern": "(Time|exported_instance|end)",
+            "thresholds": [],
+            "type": "hidden",
+            "unit": "short"
+          }
+        ],
+        "targets": [
+          {
+            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-istio\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,end,source_run,value)",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Peak latencies (1.0 percentile)",
+        "transform": "table",
+        "transparent": true,
+        "type": "table"
       }
     ],
     "refresh": false,
@@ -2908,6 +2686,6 @@
     "timezone": "",
     "title": "wrk2 Summary",
     "uid": null,
-    "version": 30
+    "version": 7
   }
 }

--- a/dashboards/grafana-wrk2-summary.json
+++ b/dashboards/grafana-wrk2-summary.json
@@ -8,10 +8,10 @@
     "slug": "wrk2-summary",
     "expires": "0001-01-01T00:00:00Z",
     "created": "2020-07-25T15:25:31Z",
-    "updated": "2020-07-27T16:38:24Z",
+    "updated": "2020-07-27T16:57:27Z",
     "updatedBy": "admin",
     "createdBy": "Anonymous",
-    "version": 10,
+    "version": 11,
     "hasAcl": false,
     "isFolder": false,
     "folderId": 0,
@@ -38,7 +38,7 @@
     "gnetId": null,
     "graphTooltip": 0,
     "id": 27,
-    "iteration": 1595860912655,
+    "iteration": 1595860912679,
     "links": [],
     "panels": [
       {
@@ -3262,7 +3262,7 @@
             "link": true,
             "linkTargetBlank": true,
             "linkTooltip": "Go to run ${__cell_3}.",
-            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=bare-metal&var-instance=${__cell_2}&var-run=${__cell_3}&time=${__cell_1}&time.window=1500000",
+            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=bare-metal&var-instance=${__cell_2}&var-run=${__cell_3}&from=${__cell_4}&to=${__cell_1}",
             "mappingType": 1,
             "pattern": "source_run",
             "thresholds": [],
@@ -3300,7 +3300,7 @@
             "dateFormat": "YYYY-MM-DD HH:mm:ss",
             "decimals": 2,
             "mappingType": 1,
-            "pattern": "(Time|exported_instance|end)",
+            "pattern": "(Time|exported_instance|end|start)",
             "thresholds": [],
             "type": "hidden",
             "unit": "short"
@@ -3308,7 +3308,7 @@
         ],
         "targets": [
           {
-            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"bare-metal\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,end,source_run,value)",
+            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"bare-metal\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,start,end,source_run,value)",
             "format": "table",
             "hide": false,
             "instant": true,
@@ -4103,7 +4103,7 @@
           "x": 16,
           "y": 27
         },
-        "id": 34,
+        "id": 76,
         "options": {},
         "pageSize": null,
         "showHeader": true,
@@ -4125,7 +4125,7 @@
             "link": true,
             "linkTargetBlank": true,
             "linkTooltip": "Go to run ${__cell_3}.",
-            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=svcmesh-linkerd&var-instance=${__cell_2}&var-run=${__cell_3}&time=${__cell_1}&time.window=1500000",
+            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=svcmesh-linkerd&var-instance=${__cell_2}&var-run=${__cell_3}&from=${__cell_4}&to=${__cell_1}",
             "mappingType": 1,
             "pattern": "source_run",
             "thresholds": [],
@@ -4163,7 +4163,7 @@
             "dateFormat": "YYYY-MM-DD HH:mm:ss",
             "decimals": 2,
             "mappingType": 1,
-            "pattern": "(Time|exported_instance|end)",
+            "pattern": "(Time|exported_instance|end|start)",
             "thresholds": [],
             "type": "hidden",
             "unit": "short"
@@ -4171,7 +4171,7 @@
         ],
         "targets": [
           {
-            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-linkerd\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,end,source_run,value)",
+            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-linkerd\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,start,end,source_run,value)",
             "format": "table",
             "hide": false,
             "instant": true,
@@ -4961,17 +4961,17 @@
         "datasource": "Prometheus",
         "fontSize": "100%",
         "gridPos": {
-          "h": 8,
+          "h": 9,
           "w": 8,
           "x": 16,
           "y": 38
         },
-        "id": 35,
+        "id": 77,
         "options": {},
         "pageSize": null,
         "showHeader": true,
         "sort": {
-          "col": 2,
+          "col": 4,
           "desc": true
         },
         "styles": [
@@ -4988,7 +4988,7 @@
             "link": true,
             "linkTargetBlank": true,
             "linkTooltip": "Go to run ${__cell_3}.",
-            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=svcmesh-istio&var-instance=${__cell_2}&var-run=${__cell_3}&time=${__cell_1}&time.window=1500000",
+            "linkUrl": "http://localhost:3000/dashboard/db/wrk2-benchmark-cockpit?var-job=svcmesh-istio&var-instance=${__cell_2}&var-run=${__cell_3}&from=${__cell_4}&to=${__cell_1}",
             "mappingType": 1,
             "pattern": "source_run",
             "thresholds": [],
@@ -5026,7 +5026,7 @@
             "dateFormat": "YYYY-MM-DD HH:mm:ss",
             "decimals": 2,
             "mappingType": 1,
-            "pattern": "(Time|exported_instance|end)",
+            "pattern": "(Time|exported_instance|end|start)",
             "thresholds": [],
             "type": "hidden",
             "unit": "short"
@@ -5034,7 +5034,7 @@
         ],
         "targets": [
           {
-            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-istio\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,end,source_run,value)",
+            "expr": "max(wrk2_benchmark_summary_latency_ms{exported_job=\"svcmesh-istio\",requested_rps=\"$rps\", p=\"1.0\"}) by (exported_instance,start,end,source_run,value)",
             "format": "table",
             "hide": false,
             "instant": true,
@@ -5104,6 +5104,6 @@
     "timezone": "",
     "title": "wrk2 Summary",
     "uid": null,
-    "version": 10
+    "version": 11
   }
 }

--- a/metrics-merger/README.md
+++ b/metrics-merger/README.md
@@ -3,11 +3,13 @@
 The `merger.py` tool and accompanying Docker build recipe implement results
 merging of individual benchmark runs. `merger.py` will query individual run
 results from Prometheus, merge the data to create a summary, then publish the
-summary to a push gateway.
+summary to a push gateway. The merger job should run after every benchmark, to
+keep the [summary dashboard](../dashboards/grafana-wrk2-summary.json)
+up to date.
 
 `merger.py` will merge all data of completed runs (`{status="done"}`) of
 (currently hard-coded) `bare-metal`, `svcmesh-linkerd`, and `svcmesh-istio`
-jobsi, The benchmark starter script `config/run_benchmark.sh` will use these
+jobs, The benchmark starter script `config/run_benchmark.sh` will use these
 job names.
 
 # Usage

--- a/metrics-merger/merger.py
+++ b/metrics-merger/merger.py
@@ -133,7 +133,9 @@ def create_summary_gauge(p, mesh, r, detailed=False):
         percs_count = percs_count + 1
         for run, lat in latencies.items():
             g.labels(p=perc, source_run=run, requested_rps=info[run]["rps"],
-                     start=info[run]["start"]*1000, end=info[run]["end"]*1000,
+                     start=info[run]["start"]*1000,
+                     # dashboard link fix: set end to 1min after actual end
+                     end = (info[run]["end"] + 60) *1000,
                      duration=info[run]["duration"]).set(lat)
 
     return g, percs_count, len(info)

--- a/metrics-merger/merger.py
+++ b/metrics-merger/merger.py
@@ -35,6 +35,20 @@ def get_completed_runs(p, mesh):
     return r
 # --
 
+def run_time_info(p, run):
+    info = {}
+    for kind in ["start", "end", "duration"]:
+        res = get_results(p,
+                'wrk2_benchmark_run_runtime{kind="%s",run="%s"}' % (kind,run))
+        try:
+            info[kind] = int(res[0]["values"][0][1])
+        except IndexError:
+            print(" !!! Run %s lacks '%s' metric." % (run,kind))
+            return None
+
+    return info
+# --
+
 def get_latency_histogram(run,detailed=False):
     # return RPS, histogram of a single run as dict 
     # <RPS>, {<percentile>: <latency in ms>, ...}
@@ -66,34 +80,40 @@ def get_latency_histogram(run,detailed=False):
 
 def get_latency_histograms(p, mesh, detailed=False):
     # get all runs for a given service mesh.
-    # Returns dict of dicts, indexed by RPS, then latency percentile:
-    # { <RPS>: { <percentile>: [ <lat>, <lat>, <lat>, ...], <percentile>:...},
-    #   <RPS>: { ...}, ...}
+    # Returns dict of latency percentiles:
+    # { <percentile>: [ <lat>, <lat>, <lat>, ...], <percentile>:...},
+    #   <percentile>: [...]}
+    # and info (doct) for each run (rps, start end, duration)
 
-    histograms={}
     if False == detailed:
         print("Mesh %s" %(mesh,))
+
+    histograms={}
+    info = {}
+
     for run in get_completed_runs(p, mesh):
         rps, h = get_latency_histogram(run, detailed)
-        if not histograms.get(rps):
-            histograms[rps]={}
+        i = run_time_info(p, run)
+        if not i:
+            continue
+        info[run] = i
+        info[run]["rps"] = rps
         for perc,lat in h.items():
-            if histograms[rps].get(perc, False):
-                histograms[rps][perc][run]=lat
+            if histograms.get(perc, False):
+                histograms[perc][run]=lat
             else:
-                histograms[rps][perc] = OrderedDict({run:lat})
+                histograms[perc] = OrderedDict({run:lat})
 
     # sort runs' latencies for each percentile
-    for rps in histograms.keys():
-        for perc in histograms[rps].keys():
-            histograms[rps][perc] = {k: v for k, v in 
-                sorted(histograms[rps][perc].items(), key=lambda item: item[1])}
+    for perc in histograms.keys():
+        histograms[perc] = {k: v for k, v in 
+            sorted(histograms[perc].items(), key=lambda item: item[1])}
 
-    return histograms
+    return histograms, info
 # --
 
 def create_summary_gauge(p, mesh, r, detailed=False):
-    histograms = get_latency_histograms(p, mesh, detailed)
+    histograms, info = get_latency_histograms(p, mesh, detailed)
 
     if detailed:
         detailed="detailed_"
@@ -101,23 +121,23 @@ def create_summary_gauge(p, mesh, r, detailed=False):
         detailed=""
 
     g = Gauge('wrk2_benchmark_summary_latency_%sms' % (detailed,),
-              '%s latency summary' % (mesh,),
-                labelnames=["p","source_run", "requested_rps"], registry=r)
+            '%s latency summary' % (mesh,),
+            labelnames=[
+                "p","source_run", "requested_rps", "start", "end", "duration"],
+                registry=r)
 
-    percs_count=0; runs_count=0
+    percs_count=0
 
     # create latency entries for all runs, per percentile
-    for rps in histograms.keys():
-        for perc, latencies in histograms[rps].items():
-            percs_count = percs_count + 1
-            runs_count=0
-            for run, lat in latencies.items():
-                runs_count = runs_count + 1
-                g.labels(p=perc, source_run=run, requested_rps=rps).set(lat)
+    for perc, latencies in histograms.items():
+        percs_count = percs_count + 1
+        for run, lat in latencies.items():
+            g.labels(p=perc, source_run=run, requested_rps=info[run]["rps"],
+                     start=info[run]["start"]*1000, end=info[run]["end"]*1000,
+                     duration=info[run]["duration"]).set(lat)
 
-    return g, percs_count, runs_count
+    return g, percs_count, len(info)
 # --
-
 #
 # -- main --
 #
@@ -146,5 +166,5 @@ for mesh in ["bare-metal", "svcmesh-linkerd", "svcmesh-istio"]:
     print("%s: %d runs with %d percentiles (coarse)" % (mesh, runs, percs))
     print("%s: %d runs with %d percentiles (detailed)" % (mesh, druns, dpercs))
 
-    push_to_gateway(pgw_url, job=mesh,
-            grouping_key={"instance":"emojivoto"}, registry=r)
+    push_to_gateway(
+          pgw_url, job=mesh, grouping_key={"instance":"emojivoto"}, registry=r)


### PR DESCRIPTION
The summary dashboard used to rely on fresh data from all benchmarks (start, duration, end timestamp of a benchmark) for creating links to each respective runs' cockpit dashboard. Since the push gateway tends to crash from disk pressure every now and then, metrics of past benchmarks would not be "fresh" anymore - this broke the links in the summary dashboard.

This PR updates metrics merger to add individual benchmarks' run time information to each summary metric, and updates the summary dashboard to use the new label fields.