### PR TITLE
metrics-merger/merger.py: use consistent help string for metrics

### DIFF
--- a/metrics-merger/merger.py
+++ b/metrics-merger/merger.py
@@ -121,7 +121,7 @@ def create_summary_gauge(p, mesh, r, detailed=False):
         detailed=""
 
     g = Gauge('wrk2_benchmark_summary_latency_%sms' % (detailed,),
-            '%s latency summary' % (mesh,),
+            '%s latency summary' % (detailed,),
             labelnames=[
                 "p","source_run", "requested_rps", "start", "end", "duration"],
                 registry=r)


### PR DESCRIPTION
Using different help strings for the same metric (with varying label)
causes pushgateway to massively spam its logs, leading to gigabytes
of log files within a few minutes.

This change uses static help strings, which addresses the
disk presure issue.

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>