### PR TITLE
Remove CT_VER env var

### DIFF
--- a/configs/orchestrator/templates/orchestrator-config.yaml
+++ b/configs/orchestrator/templates/orchestrator-config.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: orchestrator-config
-  namespace: orchestrator
-data:
-  CT_VER: ""

--- a/orchestrator/main.go
+++ b/orchestrator/main.go
@@ -191,8 +191,6 @@ spec:
         envFrom:
         - secretRef:
             name: cloud-secrets
-        - configMapRef:
-            name: orchestrator-config
         command:
         - bash
         args:


### PR DESCRIPTION
This env var is not needed any more since lokoctl automatically
downloads the CT binary.