### PR TITLE
Fix load generator sidecar charts, add "past days" param to merger

### DIFF
--- a/dashboards/grafana-wrk2-cockpit.json
+++ b/dashboards/grafana-wrk2-cockpit.json
@@ -1000,7 +1000,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "container_memory_working_set_bytes{container!~\"POD\", namespace=\"benchmark\", container=~\".*-proxy\",container!=\"\"}",
+            "expr": "container_memory_working_set_bytes{container!~\"POD\", namespace=~\"benchmark-.*\", container=~\".*-proxy\",container!=\"\"}",
             "legendFormat": "{{container}} Memory",
             "refId": "B"
           }
@@ -1297,7 +1297,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"benchmark\", container=~\".*-proxy\",container!=\"\"}",
+            "expr": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"benchmark-.*\", container=~\".*-proxy\",container!=\"\"}",
             "format": "time_series",
             "instant": false,
             "legendFormat": "{{container}} CPU seconds",


### PR DESCRIPTION
# Fix load generator sidecar charts, add "past days" param to merger

This PR includes minor fixes to the dashboard as well as adds an optional "past days" parameter to the metrics merger. The default past days remains "7".

# How to use

* Dashboard: upload to Grafana, review a benchmark run.
* Metrics merger: run `python3 metrics-merger/merger.py <prometheus URL:port> <pushgateway:port> <past days; e.g. 20>

# Testing done
Uploaded dashboard to Grafana and reviewed a run, and ran metrics-merger with past days set to 20.