### PR TITLE
dashboards/cockpit: fix per-thread chart labels

### DIFF
--- a/dashboards/grafana-wrk2-cockpit-orchestrator.json
+++ b/dashboards/grafana-wrk2-cockpit-orchestrator.json
@@ -406,7 +406,7 @@
           {
             "expr": "wrk2_benchmark_current_rps{exported_instance=\"$instance\",run=\"$run\",exported_job=\"$job\",cluster=\"$cluster\"}",
             "instant": false,
-            "legendFormat": "{{thread}}",
+            "legendFormat": "{{label}}{{thread}}",
             "refId": "A"
           }
         ],
@@ -653,7 +653,7 @@
           {
             "expr": "wrk2_benchmark_average_rps{exported_instance=\"$instance\",run=\"$run\",exported_job=\"$job\",cluster=\"$cluster\"}",
             "instant": false,
-            "legendFormat": "{{thread}}",
+            "legendFormat": "{{label}}{{thread}}",
             "refId": "A"
           }
         ],

--- a/dashboards/grafana-wrk2-cockpit.json
+++ b/dashboards/grafana-wrk2-cockpit.json
@@ -406,7 +406,7 @@
           {
             "expr": "wrk2_benchmark_current_rps{exported_instance=\"$instance\",run=\"$run\",exported_job=\"$job\"}",
             "instant": false,
-            "legendFormat": "{{thread}}",
+            "legendFormat": "{{label}}{{thread}}",
             "refId": "A"
           }
         ],
@@ -653,7 +653,7 @@
           {
             "expr": "wrk2_benchmark_average_rps{exported_instance=\"$instance\",run=\"$run\",exported_job=\"$job\"}",
             "instant": false,
-            "legendFormat": "{{thread}}",
+            "legendFormat": "{{label}}{{thread}}",
             "refId": "A"
           }
         ],


### PR DESCRIPTION
Per-thread chart data sometimes does not contain the label `{{thread}}` but instead uses the label `{{label}}`.
This PR ships a minor change to fix per-thread chart displays which broke from the above.