### PR TITLE
fix benchmark pod cpu usage chart

### DIFF
--- a/dashboards/grafana-wrk2-cockpit-orchestrator.json
+++ b/dashboards/grafana-wrk2-cockpit-orchestrator.json
@@ -406,7 +406,7 @@
           {
             "expr": "wrk2_benchmark_current_rps{exported_instance=\"$instance\",run=\"$run\",exported_job=\"$job\",cluster=\"$cluster\"}",
             "instant": false,
-            "legendFormat": "{{thread}}",
+            "legendFormat": "{{label}}{{thread}}",
             "refId": "A"
           }
         ],
@@ -653,7 +653,7 @@
           {
             "expr": "wrk2_benchmark_average_rps{exported_instance=\"$instance\",run=\"$run\",exported_job=\"$job\",cluster=\"$cluster\"}",
             "instant": false,
-            "legendFormat": "{{thread}}",
+            "legendFormat": "{{label}}{{thread}}",
             "refId": "A"
           }
         ],

--- a/dashboards/grafana-wrk2-cockpit.json
+++ b/dashboards/grafana-wrk2-cockpit.json
@@ -1297,7 +1297,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"benchmark-.*\", container=~\".*-proxy\",container!=\"\"}",
+            "expr": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~\"benchmark-.*\", container=~\".*-proxy\",container!=\"\"}",
             "format": "time_series",
             "instant": false,
             "legendFormat": "{{container}} CPU seconds",

--- a/dashboards/grafana-wrk2-cockpit.json
+++ b/dashboards/grafana-wrk2-cockpit.json
@@ -406,7 +406,7 @@
           {
             "expr": "wrk2_benchmark_current_rps{exported_instance=\"$instance\",run=\"$run\",exported_job=\"$job\"}",
             "instant": false,
-            "legendFormat": "{{thread}}",
+            "legendFormat": "{{label}}{{thread}}",
             "refId": "A"
           }
         ],
@@ -653,7 +653,7 @@
           {
             "expr": "wrk2_benchmark_average_rps{exported_instance=\"$instance\",run=\"$run\",exported_job=\"$job\"}",
             "instant": false,
-            "legendFormat": "{{thread}}",
+            "legendFormat": "{{label}}{{thread}}",
             "refId": "A"
           }
         ],


### PR DESCRIPTION
Fix a typo in the wrk2-cockpit dashboard which broke the benchmark pod CPU usage chart: `namespace="benchmark-.*"` => `namespace=~"benchmark-.*.`