### PR TITLE
bug: Fix orchestrator and metrics-merger

### DIFF
--- a/configs/metrics-merger/templates/metrics-merger.yaml
+++ b/configs/metrics-merger/templates/metrics-merger.yaml
@@ -25,7 +25,7 @@ spec:
         imagePullPolicy: Always
         env:
         - name: PROMETHEUS_URL
-          value: "http://prometheus-operator-prometheus.monitoring:9090"
+          value: {{ .Values.prometheusServiceUrl }}
         args:
-        - "http://prometheus-operator-prometheus.monitoring:9090"
-        - "pushgateway.monitoring:9091"
+        - {{ .Values.prometheusServiceUrl }}
+        - {{ .Values.pushgatewayURL }}

--- a/configs/metrics-merger/values.yaml
+++ b/configs/metrics-merger/values.yaml
@@ -1,0 +1,2 @@
+prometheusServiceUrl: "http://prometheus-operator-kube-p-prometheus.monitoring:9090"
+pushgatewayURL: "pushgateway.monitoring:9091"

--- a/configs/orchestrator/cluster-install-configs/run-smi-benchmark.sh
+++ b/configs/orchestrator/cluster-install-configs/run-smi-benchmark.sh
@@ -59,7 +59,7 @@ done
 
 # Make an entry in the OC about this BC
 # This uses service account credentials to talk to apiserver
-kubectl -n monitoring patch prometheus prometheus-operator-prometheus --type merge --patch '{"spec":{"additionalScrapeConfigs":{"name":"scrape-config","key":"scrape.yaml"}}}'
+kubectl -n monitoring patch prometheus prometheus-operator-kube-p-prometheus --type merge --patch '{"spec":{"additionalScrapeConfigs":{"name":"scrape-config","key":"scrape.yaml"}}}'
 
 if ! kubectl -n monitoring get secret scrape-config; then
   err "could not find secret 'scrape-config' in 'monitoring' namespace on orchestrating cluster"

--- a/configs/orchestrator/templates/cloud-secrets.yaml
+++ b/configs/orchestrator/templates/cloud-secrets.yaml
@@ -4,11 +4,11 @@ metadata:
   name: cloud-secrets
   namespace: orchestrator
 data:
-  {{if .Values.clouds.packet.token}}
-  PACKET_AUTH_TOKEN: {{ .Values.clouds.packet.token | b64enc }}
+  {{if .Values.clouds.em.token}}
+  EQUINIX_METAL_AUTH_TOKEN: {{ .Values.clouds.em.token | b64enc }}
   {{end}}
-  {{if .Values.clouds.packet.projectID}}
-  PACKET_PROJECT_ID: {{ .Values.clouds.packet.projectID | b64enc }}
+  {{if .Values.clouds.em.projectID}}
+  EQUINIX_METAL_PROJECT_ID: {{ .Values.clouds.em.projectID | b64enc }}
   {{end}}
   {{if .Values.clouds.aws.accessKeyID}}
   AWS_ACCESS_KEY_ID: {{ .Values.clouds.aws.accessKeyID | b64enc }}

--- a/configs/orchestrator/templates/deployment.yaml
+++ b/configs/orchestrator/templates/deployment.yaml
@@ -20,9 +20,9 @@ spec:
       - image: quay.io/kinvolk/smb-orchestrator
         name: orchestrator
         env:
-        {{ if .Values.clouds.packet.regionEIPs -}}
+        {{ if .Values.clouds.em.regionEIPs -}}
         - name: REGION_EIPS
-          value: {{.Values.clouds.packet.regionEIPs}}
+          value: {{.Values.clouds.em.regionEIPs}}
         {{ end -}}
         - name: AWS_REGIONS
           value: {{.Values.clouds.aws.regions}}

--- a/configs/orchestrator/templates/rbac.yaml
+++ b/configs/orchestrator/templates/rbac.yaml
@@ -12,7 +12,7 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resourceNames:
-  - prometheus-operator-prometheus
+  - prometheus-operator-kube-p-prometheus
   resources:
   - prometheuses
   verbs:

--- a/configs/orchestrator/values.yaml
+++ b/configs/orchestrator/values.yaml
@@ -43,7 +43,7 @@ clouds:
     # us-east-1,us-west-1
     regions:
 
-  packet:
+  em:
     token:
     projectID:
     # List of comma separated region=EIP. This EIP is used to expose the Prometheus on the


### PR DESCRIPTION
Prometheus has changed the prometheus object name and the service name,
due to which orchestrator failed. Also EM metal_project_id was
not getting populated as it has a different variable name with which we
were populating it.

Also added a new parameters for metrics-merger.

Signed-off-by: knrt10 <tripathi.kautilya@gmail.com>

# Testing done

Yes
