### PR TITLE
Add a job to download benchmark-containers repository

### DIFF
--- a/configs/orchestrator/cluster-install-configs/aws/aws.lokocfg
+++ b/configs/orchestrator/cluster-install-configs/aws/aws.lokocfg
@@ -5,6 +5,10 @@ variable "route53_zone_id" {}
 variable "aws_access_key_id" {}
 variable "aws_secret_access_key" {}
 variable "region" {}
+variable "benchmark_worker_count" {}
+variable "benchmark_instance_type" {}
+variable "benchmark_os_arch" {}
+variable "benchmark_os_channel" {}
 
 cluster "aws" {
   asset_dir        = "./assets"
@@ -18,23 +22,27 @@ cluster "aws" {
 
   # ignore_x509_cn_check = true
 
-  worker_pool "amd" {
+  worker_pool "general" {
     # TODO: Figure out the count and instance type.
-    count         = 2
+    count = 2
     # instance_type = var.workers_type
 
     ssh_pubkeys = [var.ssh_pubkey]
   }
 
-  worker_pool "arm" {
-    # TODO: Figure out the count.
-    count         = 1
-    instance_type = "m6g.medium"
-    os_arch       = "arm64"
-    os_channel    = "alpha"
+  worker_pool "benchmark" {
+    count         = var.benchmark_worker_count
+    instance_type = var.benchmark_instance_type
+    os_arch       = var.benchmark_os_arch
+    os_channel    = var.benchmark_os_channel
     ssh_pubkeys   = [var.ssh_pubkey]
-    taints        = {
-      "beta.kubernetes.io/arch" = "arm:NoSchedule"
+
+    taints = {
+      "role" = "benchmark:NoSchedule"
+    }
+
+    labels = {
+      "role" = "benchmark"
     }
 
     # TODO: remove this once https://github.com/kinvolk/lokomotive/issues/839 is fixed.

--- a/configs/orchestrator/cluster-install-configs/aws/aws.vars.envsubst
+++ b/configs/orchestrator/cluster-install-configs/aws/aws.vars.envsubst
@@ -1,8 +1,15 @@
+# Cluster specific config.
 cluster_name = "$CLUSTER_NAME"
 region       = "$REGION"
 
+# Same across all clusters.
 ssh_pubkey            = "$SSH_PUB_KEY"
 route53_zone          = "$AWS_ROUTE53_ZONE"
 route53_zone_id       = "$AWS_ROUTE53_ZONE_ID"
 aws_access_key_id     = "$AWS_ACCESS_KEY_ID"
 aws_secret_access_key = "$AWS_SECRET_ACCESS_KEY"
+
+benchmark_worker_count  = $BENCHMARK_WORKER_COUNT
+benchmark_instance_type = "$BENCHMARK_INSTANCE_TYPE"
+benchmark_os_arch       = "$BENCHMARK_OS_ARCH"
+benchmark_os_channel    = "$BENCHMARK_OS_CHANNEL"

--- a/configs/orchestrator/templates/cloud-secrets.yaml
+++ b/configs/orchestrator/templates/cloud-secrets.yaml
@@ -25,3 +25,15 @@ data:
   {{if .Values.clouds.aws.route53ZoneID}}
   AWS_ROUTE53_ZONE_ID: {{ .Values.clouds.aws.route53ZoneID | b64enc }}
   {{end}}
+  {{if .Values.clouds.aws.benchmarkWorkerCount }}
+  BENCHMARK_WORKER_COUNT: {{ .Values.clouds.aws.benchmarkWorkerCount | quote | b64enc }}
+  {{end}}
+  {{if .Values.clouds.aws.benchmarkInstanceType }}
+  BENCHMARK_INSTANCE_TYPE: {{ .Values.clouds.aws.benchmarkInstanceType | b64enc }}
+  {{end}}
+  {{if .Values.clouds.aws.benchmarkOSArch }}
+  BENCHMARK_OS_ARCH: {{ .Values.clouds.aws.benchmarkOSArch | b64enc }}
+  {{end}}
+  {{if .Values.clouds.aws.benchmarkOSChannel }}
+  BENCHMARK_OS_CHANNEL: {{ .Values.clouds.aws.benchmarkOSChannel | b64enc }}
+  {{end}}

--- a/configs/orchestrator/templates/download-benchmark-containers.yaml
+++ b/configs/orchestrator/templates/download-benchmark-containers.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: download-benchmark-containers-repository
+  namespace: orchestrator
+spec:
+  template:
+    metadata:
+      labels:
+        pvc: binaries
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: download-benchmark-containers-repository
+        image: golang
+        env:
+        - name: BRANCH
+          value: {{.Values.benchMarkContainers.branch}}
+        command:
+        - bash
+        args:
+        - -c
+        - 'cd /binaries && git clone https://github.com/kinvolk/benchmark-containers && cd benchmark-containers && git checkout $BRANCH'
+        volumeMounts:
+        - name: binaries
+          mountPath: /binaries
+      serviceAccountName: downloader
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: pvc
+                operator: In
+                values:
+                - binaries
+            topologyKey: kubernetes.io/hostname
+      volumes:
+      - name: binaries
+        persistentVolumeClaim:
+          claimName: binaries

--- a/configs/orchestrator/values.yaml
+++ b/configs/orchestrator/values.yaml
@@ -8,6 +8,12 @@ charts:
   # clusters.
   branch: master
 
+benchMarkContainers:
+  # Use a different branch if you are using experimental version of this repository. This is under
+  # charts because the charts under configs repo are downloaded to be deployed on the benchmarking
+  # clusters.
+  branch: master
+
 terraform:
   version: 0.13.6
 

--- a/configs/orchestrator/values.yaml
+++ b/configs/orchestrator/values.yaml
@@ -47,7 +47,11 @@ clouds:
     route53ZoneID:
     # List of comma separated regions you want to deploy the benchmarking clusters to. e.g.:
     # us-east-1,us-west-1
-    regions:
+    regions: us-west-1
+    benchmarkWorkerCount: 1
+    benchmarkInstanceType: t3.medium
+    benchmarkOSArch: amd64
+    benchmarkOSChannel: stable
 
   em:
     token:

--- a/orchestrator/pkg/util/job.go
+++ b/orchestrator/pkg/util/job.go
@@ -93,8 +93,9 @@ type Job struct {
 // The string is trimmed down to 18 characters. That is the maximum allowed length by lokomotive.
 func GenerateName(region string) string {
 	t := time.Now()
-	ret := fmt.Sprintf("bc-%s-%d-%d%d%d%d%d%d",
-		region, rand.Int(), t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
+	rand.Seed(time.Now().UnixNano())
+	ret := fmt.Sprintf("bc-%s-%d-%d%d%d",
+		region, rand.Int(), t.Hour(), t.Minute(), t.Second())
 
 	return ret[:18]
 }


### PR DESCRIPTION
Parameterise the AWS cloud so as to allow user to specify things like machine type, number of machines, arch, os channel, etc.