### PR TITLE
orchestrator: Modify AWS machines to match OCI

### DIFF
--- a/configs/orchestrator/cluster-install-configs/aws/aws.lokocfg
+++ b/configs/orchestrator/cluster-install-configs/aws/aws.lokocfg
@@ -14,6 +14,7 @@ cluster "aws" {
   asset_dir        = "./assets"
   cluster_name     = var.cluster_name
   controller_count = 1
+  controller_type  = "t3.xlarge"
   dns_zone         = var.route53_zone
   dns_zone_id      = var.route53_zone_id
   region           = var.region
@@ -23,11 +24,9 @@ cluster "aws" {
   # ignore_x509_cn_check = true
 
   worker_pool "general" {
-    # TODO: Figure out the count and instance type.
-    count = 2
-    # instance_type = var.workers_type
-
-    ssh_pubkeys = [var.ssh_pubkey]
+    count         = 2
+    instance_type = "t3.xlarge"
+    ssh_pubkeys   = [var.ssh_pubkey]
   }
 
   worker_pool "benchmark" {


### PR DESCRIPTION
This commit modifies the machine type of the control plane and the
generic worker pool from the default type `t3.small` to `t3.xlarge`.

This matching is done to ensure that the non-matching hardware does not
influence the end benchmarking results.
