### PR TITLE
metrics-merger: make exported_jobs a parameter

### DIFF
--- a/configs/metrics-merger/templates/metrics-merger.yaml
+++ b/configs/metrics-merger/templates/metrics-merger.yaml
@@ -29,3 +29,4 @@ spec:
         args:
         - {{ .Values.prometheusServiceUrl }}
         - {{ .Values.pushgatewayURL }}
+        - {{ .Values.exportedJobs }}

--- a/configs/metrics-merger/values.yaml
+++ b/configs/metrics-merger/values.yaml
@@ -1,2 +1,3 @@
 prometheusServiceUrl: "http://prometheus-operator-kube-p-prometheus.monitoring:9090"
 pushgatewayURL: "pushgateway.monitoring:9091"
+exportedJobs: "bare-metal,svcmesh-linkerd,svcmesh-istio"

--- a/metrics-merger/merger.py
+++ b/metrics-merger/merger.py
@@ -148,9 +148,9 @@ def create_summary_gauge(p, mesh, r, detailed=False, past_days=7):
 
 if 3 > len(argv):
     print(
-       'Command line error: Prometheus URL and push gateway are required.')
+       'Command line error: Prometheus URL and push gateway, and list of exported_jobs are required.')
     print('Usage:')
-    print('  %s <Prometheus URL> <push gateway host:port> [<past-days>]'
+    print('  %s <Prometheus URL> <push gateway host:port> <exported_job>[,<exported_job>[,...]] [<past-days>]'
             % (argv[0],))
     exit(1)
 
@@ -158,13 +158,15 @@ prometheus_url = argv[1]
 pgw_url = argv[2]
 past_days=7
 
-if 4 == len(argv):
+exported_jobs = argv[3].split(",")
+
+if 5 == len(argv):
     past_days=int(argv[3])
 
 environ['PROMETHEUS_URL'] = prometheus_url
 p = Prometheus()
 
-for mesh in ["bare-metal", "svcmesh-linkerd", "svcmesh-istio"]:
+for mesh in exported_jobs:
 
     r = CollectorRegistry()
     workaround = mesh


### PR DESCRIPTION
The metrics merger was using hard-coded values "bare-metal",
"svcmesh-istio", and "svcmesh-linkerd". This breaks benchmark metrics
merging where different job names are used.

This change makes the exported_jobs a command line parameter; the Helm
chart defaults to the 3 job names which were formerly hard-coded.