### PR TITLE
Add Sidecar to Istio configuration

### DIFF
--- a/configs/benchmark/templates/sidecar.yaml
+++ b/configs/benchmark/templates/sidecar.yaml
@@ -1,0 +1,11 @@
+{{- if eq .Values.wrk2.serviceMesh "istio" }}
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: wrk2
+  namespace: {{.Release.Namespace}}
+spec:
+  egress:
+  - hosts:
+    - "*/*" # Ensure benchmark can see all servers
+{{- end }}

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -224,7 +224,17 @@ function run_benchmarks() {
                 # this sometimes fails with a namespace error, works the 2nd time
                 sleep 5
                 lokoctl component apply experimental-linkerd; }
-
+            cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: restrict-visibility
+  namespace: istio-system
+spec:
+  egress:
+  - hosts:
+    - ./* # Limit visiblity of emojivoto pods
+EOF
             grace "kubectl get pods --all-namespaces | grep linkerd | grep -v Running"
 
             install_emojivoto linkerd


### PR DESCRIPTION
This is standard configuration recommended in
https://istio.io/latest/docs/ops/deployment/performance-and-scalability/
and used by ~all production Istio users.

# Add Sidecar to Istio configuration

This is standard configuration recommended in
https://istio.io/latest/docs/ops/deployment/performance-and-scalability/
and used by ~all production Istio users.

## How to use

No changes needed to standard benchmark script

## Testing done
